### PR TITLE
Update peerDependencies to React 15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "jquery": "^2.1.4",
     "lodash": "^3.10.1",
     "react-component-gulp-tasks": "^0.7.0",
-    "react": "~15.3.0",
-    "react-dom": "~15.3.0"
+    "react": "~15.4.0",
+    "react-dom": "~15.4.0"
   },
   "peerDependencies": {
-    "react": "~15.3.0",
-    "react-dom": "~15.3.0"
+    "react": "~15.4.0",
+    "react-dom": "~15.4.0"
   },
   "browserify-shim": {
     "react": "global:React"


### PR DESCRIPTION
The project seems to work fine with React 15.4 so this stops npm complaining about unmet peer dependencies when using React 15.4