### PR TITLE
Cleanup npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "responsive",
     "image gallery",
     "images"
+  ],
+  "files": [
+    "dist",
+    "lib"
   ]
 }


### PR DESCRIPTION
Removes examples, tests, original source code, gulpfile and various *.swo files from the NPM package, reducing the size from 1.66 MB to 30.4 KB.