### PR TITLE
added missing , to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [http://neptunian.github.io/react-photo-gallery/](http://neptunian.github.io/react-photo-gallery/)
 
-## Direct CodeSandbox Links with Examples and Use Cases 
+## Direct CodeSandbox Links with Examples and Use Cases
 
 * [Basic](https://codesandbox.io/s/9yx911wl9y)
 * [With Lightbox](https://codesandbox.io/s/5vn3lvz2n4)
@@ -63,7 +63,7 @@ const PHOTO_SET = [
   },
   {
     src: 'http://example.com/example/img2.jpg',
-    width: 1 
+    width: 1,
     height: 1
   }
 ];
@@ -76,8 +76,8 @@ Property        |       Type            |       Default         |       Descript
 :-----------------------|:--------------|:--------------|:--------------------------------
 photos | array  | undefined  | required; array of objects
 columns | number  | 3  | optional; number of photos per row
-onClick | function  | undefined  | optional; do something when the user clicks a photo; receives arguments event and an object containing the index, photo obj originally sent and the next and previous photos in the gallery if they exist 
-margin | number  | 2  | optional; number of margin pixels around each entire image 
+onClick | function  | undefined  | optional; do something when the user clicks a photo; receives arguments event and an object containing the index, photo obj originally sent and the next and previous photos in the gallery if they exist
+margin | number  | 2  | optional; number of margin pixels around each entire image
 ImageComponent | function | default component | optional; use a different image component than the default provided to display your photo
 
 ### Photos array item properties (passed into Gallery's photos property)


### PR DESCRIPTION
Hello,
Thanks for your work.

This fixes issue of missing `,` to the sample code in readme.  

