### PR TITLE
Removed module entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "6.0.29",
   "description": "Responsive React Photo Gallery Component",
   "main": "lib/Gallery.js",
-  "module": "dist/react-photo-gallery.es.js",
   "author": "Sandra Gonzales",
   "license": "MIT",
   "homepage": "https://github.com/neptunian/react-photo-gallery",


### PR DESCRIPTION
Sorry if I missed something, but when I `npm i` this package I do not have any `dist` folder. Hence some bundlers (e.g., `parcel`) break as they respect the `module` field and do not fallback in situations when the entry is invalid.

(The option to fix this is to actually create / supply the ESM output to dist, but I did not look close enough to see what needs to be changed to enable this (again))

Thanks for the great project! :+1: