### PR TITLE
Make extending of the last row optional

### DIFF
--- a/__test__/__snapshots__/Gallery.test.js.snap
+++ b/__test__/__snapshots__/Gallery.test.js.snap
@@ -5,6 +5,7 @@ exports[`renders correctly 1`] = `
   columns={3}
   direction="row"
   margin={2}
+  minImagesToExtendLastRow={2}
   onClick={[Function]}
   photos={
     Array [
@@ -558,6 +559,7 @@ exports[`renders correctly after click 1`] = `
   columns={3}
   direction="row"
   margin={2}
+  minImagesToExtendLastRow={2}
   onClick={[Function]}
   photos={
     Array [
@@ -1111,6 +1113,7 @@ exports[`renders correctly with direction set to column 1`] = `
   columns={3}
   direction="column"
   margin={2}
+  minImagesToExtendLastRow={2}
   onClick={[Function]}
   photos={
     Array [

--- a/__test__/utils.test.js
+++ b/__test__/utils.test.js
@@ -4,38 +4,62 @@ import { computeSizes } from '../src/utils';
 import photos from './test-photo-data';
 
 describe('the round function', () => {
-  test('100.12345 to two places', () => expect(round(100.12345,2)).toBe(100.12));  
-  test('100.29 to three places', () => expect(round(100.29,1)).toBe(100.3));  
-  test('100.9 with no decimals arg', () => expect(round(100.9)).toBe(101));  
+  test('100.12345 to two places', () => expect(round(100.12345, 2)).toBe(100.12));
+  test('100.29 to three places', () => expect(round(100.29, 1)).toBe(100.3));
+  test('100.9 with no decimals arg', () => expect(round(100.9)).toBe(101));
 });
 
 describe('the ratio function', () => {
-  test('width of 3 and height of 4', () => expect(ratio({width:3,height:4})).toBe(0.75));
-  test('width of 800 and height of 600', () => expect(ratio({width:800,height:600})).toBe(1.33));
-  test('width of 1 and height of 1', () => expect(ratio({width:1,height:1})).toBe(1));
+  test('width of 3 and height of 4', () => expect(ratio({ width: 3, height: 4 })).toBe(0.75));
+  test('width of 800 and height of 600', () => expect(ratio({ width: 800, height: 600 })).toBe(1.33));
+  test('width of 1 and height of 1', () => expect(ratio({ width: 1, height: 1 })).toBe(1));
 });
 
 describe('the computeSizes function called with 7 images and 3 columns', () => {
-	const width = 1138;
-	const columns = 3;
-	const margin = 2;
-	const newPhotos = computeSizes({width, margin, columns, photos});
-	const newPhotosNoWidth = computeSizes({width: 0, margin, columns, photos});
+  const width = 1138;
+  const columns = 3;
+  const margin = 2;
+  const minImagesToExtendLastRow = 2;
+  const newPhotos = computeSizes({ width, margin, columns, photos, minImagesToExtendLastRow });
+  const newPhotosNoWidth = computeSizes({ width: 0, margin, columns, photos, minImagesToExtendLastRow });
 
-	test('width of no length to return empty array', () => expect(newPhotosNoWidth.length).toBe(0));
-	test('photos array to be same length', () => expect(newPhotos.length).toBe(photos.length));
-	test('1st image width', () => expect(newPhotos[0].width).toBe(370.4));
-	test('1st image height', () => expect(newPhotos[0].height).toBe(246.9));
-	test('2nd image width', () => expect(newPhotos[1].width).toBe(370.4));
-	test('2nd image height', () => expect(newPhotos[1].height).toBe(246.9));
-	test('3rd image width', () => expect(newPhotos[2].width).toBe(385.2));
-	test('3rd image height', () => expect(newPhotos[2].height).toBe(246.9));
-	test('4th image width', () => expect(newPhotos[3].width).toBe(276));
-	test('4th image height', () => expect(newPhotos[3].height).toBe(184));
-	test('5th image width', () => expect(newPhotos[4].width).toBe(574));
-	test('5th image height', () => expect(newPhotos[4].height).toBe(184));
-	test('6th image width', () => expect(newPhotos[5].width).toBe(276));
-	test('6th image height', () => expect(newPhotos[5].height).toBe(184));
-	test('7th image width', () => expect(newPhotos[6].width).toBe(378));
-	test('7th image height', () => expect(newPhotos[6].height).toBe(255.4));
+  test('width of no length to return empty array', () => expect(newPhotosNoWidth.length).toBe(0));
+  test('photos array to be same length', () => expect(newPhotos.length).toBe(photos.length));
+  test('1st image width', () => expect(newPhotos[0].width).toBe(370.4));
+  test('1st image height', () => expect(newPhotos[0].height).toBe(246.9));
+  test('2nd image width', () => expect(newPhotos[1].width).toBe(370.4));
+  test('2nd image height', () => expect(newPhotos[1].height).toBe(246.9));
+  test('3rd image width', () => expect(newPhotos[2].width).toBe(385.2));
+  test('3rd image height', () => expect(newPhotos[2].height).toBe(246.9));
+  test('4th image width', () => expect(newPhotos[3].width).toBe(276));
+  test('4th image height', () => expect(newPhotos[3].height).toBe(184));
+  test('5th image width', () => expect(newPhotos[4].width).toBe(574));
+  test('5th image height', () => expect(newPhotos[4].height).toBe(184));
+  test('6th image width', () => expect(newPhotos[5].width).toBe(276));
+  test('6th image height', () => expect(newPhotos[5].height).toBe(184));
+  test('7th image width', () => expect(newPhotos[6].width).toBe(378));
+  test('7th image height', () => expect(newPhotos[6].height).toBe(255.4));
+});
+
+describe('the computeSizes function called with 7 images, 5 columns and without extendimg', () => {
+  const width = 1138;
+  const columns = 5;
+  const margin = 2;
+  const minImagesToExtendLastRow = 1;
+
+  const newPhotos = computeSizes({ width, margin, columns, photos, minImagesToExtendLastRow });
+  test('1st image width', () => expect(newPhotos[0].width).toBe(182.7));
+  test('1st image height', () => expect(newPhotos[0].height).toBe(121.8));
+  test('2nd image width', () => expect(newPhotos[1].width).toBe(182.7));
+  test('2nd image height', () => expect(newPhotos[1].height).toBe(121.8));
+  test('3rd image width', () => expect(newPhotos[2].width).toBe(190));
+  test('3rd image height', () => expect(newPhotos[2].height).toBe(121.8));
+  test('4th image width', () => expect(newPhotos[3].width).toBe(182.7));
+  test('4th image height', () => expect(newPhotos[3].height).toBe(121.8));
+  test('5th image width', () => expect(newPhotos[4].width).toBe(380));
+  test('5th image height', () => expect(newPhotos[4].height).toBe(121.8));
+  test('6th image width', () => expect(newPhotos[5].width).toBe(568.8));
+  test('6th image height', () => expect(newPhotos[5].height).toBe(379.2));
+  test('7th image width', () => expect(newPhotos[6].width).toBe(561.2));
+  test('7th image height', () => expect(newPhotos[6].height).toBe(379.2));
 });

--- a/examples/src/ExampleBasic.js
+++ b/examples/src/ExampleBasic.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import Gallery from 'react-photo-gallery';
 
-const ExampleBasic = ({photos, columns, title, direction}) => {
-    return (
-      <div>
-        <h2>{title}</h2>
-        <Gallery photos={photos} columns={columns} direction={direction}/>
-      </div>
-    );
-}
+const ExampleBasic = ({ photos, columns, title, direction, minImagesToExtendLastRow }) => {
+  return (
+    <div>
+      <h2>{title}</h2>
+      <Gallery
+        photos={photos}
+        columns={columns}
+        direction={direction}
+        minImagesToExtendLastRow={minImagesToExtendLastRow}
+      />
+    </div>
+  );
+};
 
 export default ExampleBasic;

--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -17,7 +17,6 @@ class App extends React.Component {
     this.loadPhotos();
   }
   loadPhotos() {
-
     const urlParams = {
       api_key: '372ef3a005d9b9df062b8240c326254d',
       photoset_id: '72157680705961676',
@@ -55,39 +54,48 @@ class App extends React.Component {
         photos: this.state.photos ? this.state.photos.concat(photos) : photos,
       });
     });
-
   }
 
   render() {
     if (this.state.photos) {
       const width = this.state.width;
       return (
-        <Measure bounds onResize={(contentRect) => this.setState({ width: contentRect.bounds.width })}>
-        {
-          ({ measureRef }) => {
-            if (width < 1 ){
-              return <div ref={measureRef}></div>;
+        <Measure bounds onResize={contentRect => this.setState({ width: contentRect.bounds.width })}>
+          {({ measureRef }) => {
+            if (width < 1) {
+              return <div ref={measureRef} />;
             }
-					  let columns = 1;
-					  if (width >= 480){
-						  columns = 2;
-					  }
-					  if (width >= 1024){
-						  columns = 3;
-					  }
-					  if (width >= 1824){
-						  columns = 4;
-					  }
-            return <div ref={measureRef} className="App">
-                <ExampleBasic title={'Basic Row Layout'} columns={columns} photos={this.state.photos.slice(0,6)} />
-                <ExampleBasic title={'Basic Column Layout'} direction="column" columns={columns} photos={this.state.photos.slice(6, 12)} />
+            let columns = 1;
+            if (width >= 480) {
+              columns = 2;
+            }
+            if (width >= 1024) {
+              columns = 3;
+            }
+            if (width >= 1824) {
+              columns = 4;
+            }
+            return (
+              <div ref={measureRef} className="App">
+                <ExampleBasic
+                  title={'Basic Row Layout'}
+                  columns={columns}
+                  minImagesToExtendLastRow={3}
+                  photos={this.state.photos.slice(0, 8)}
+                />
+                <ExampleBasic
+                  title={'Basic Column Layout'}
+                  direction="column"
+                  columns={columns}
+                  photos={this.state.photos.slice(6, 12)}
+                />
                 <ExampleWithLightbox columns={columns} photos={this.state.photos.slice(12, 18)} />
                 <ExampleCustomComponentSelection columns={columns} photos={this.state.photos.slice(18, 26)} />
                 <ExampleDynamicLoading columns={columns} photos={this.state.photos} />
               </div>
-          }
-        }
-		    </Measure>
+            );
+          }}
+        </Measure>
       );
     } else {
       return (

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -30,14 +30,14 @@ class Gallery extends React.Component {
   render() {
     const { ImageComponent = Photo } = this.props;
     // subtract 1 pixel because the browser may round up a pixel
-    const { columns, margin, onClick, direction } = this.props;
+    const { columns, margin, onClick, direction, minImagesToExtendLastRow } = this.props;
     const photos = this.props.photos;
     const width = this.state.containerWidth - 1;
     let galleryStyle, thumbs;
 
     if (direction === 'row') {
       galleryStyle = { display: 'flex', flexWrap: 'wrap', flexDirection: 'row' };
-      thumbs = computeSizes({ width, columns, margin, photos });
+      thumbs = computeSizes({ width, columns, margin, photos, minImagesToExtendLastRow });
     }
     if (direction === 'column') {
       galleryStyle = { position: 'relative' };
@@ -75,12 +75,14 @@ Gallery.propTypes = {
   columns: PropTypes.number,
   margin: PropTypes.number,
   ImageComponent: PropTypes.func,
+  minImagesToExtendLastRow: PropTypes.number,
 };
 
 Gallery.defaultProps = {
   columns: 3,
   margin: 2,
   direction: 'row',
+  minImagesToExtendLastRow: 2,
 };
 
 export default Gallery;

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export function ratio({ width, height }) {
 // margin between photos Gallery prop, and columns Gallery prop.
 // calculates, sizes based on columns and returns the photos array
 // with new height/width props in each object
-export function computeSizes({ photos, columns, width, margin }) {
+export function computeSizes({ photos, columns, width, margin, minImagesToExtendLastRow }) {
   if (!width) {
     return [];
   }
@@ -30,11 +30,10 @@ export function computeSizes({ photos, columns, width, margin }) {
     const totalRatio = row.reduce((result, photo) => result + ratio(photo), 0);
     const rowWidth = width - row.length * (margin * 2);
 
-    // assign height, but let height of a single photo in the last
-    // row not expand across columns so divide by columns
-    const height = (rowIndex !== lastRowIndex || row.length > 1) // eslint-disable-line
+    // assign height and expand the last row if needed
+    const height = rowIndex !== lastRowIndex || row.length >= minImagesToExtendLastRow // eslint-disable-line
         ? rowWidth / totalRatio
-        : rowWidth / columns / totalRatio;
+        : rowWidth / totalRatio * (row.length / columns);
 
     return row.map(photo => ({
       ...photo,


### PR DESCRIPTION
Hi all!

Images in the last row are extended to fill all the space regardless of the **columns** property (only single image will keep its size). The last row looks too giant if **columns** value is more than 3.
https://codesandbox.io/s/0olwwy50n0

So I amended the calculation of images width in the last row in **utils.js** file.
The default behavior hasn't been changed. But now it's possible to configure this behavior (set min count of images in the last row when it should be extended).
Also I added tests for it, changed styling in several files and changed the first example in order see that problem is solved (2 images don't fill the full size anymore).

This library is awesome, I really like it! Thank you very much!
I'm using it in production and the behavior described above has become a problem for me.
Could you please review this PR and provide your feedback about whether it's possible to commit my changes and publish the new version to npm?