### PR TITLE
Suppress Gallery layout trigger when parent element is hidden (width=0)

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -24,7 +24,7 @@ const Gallery = React.memo(function Gallery({
     const observer = new ResizeObserver(entries => {
       // only do something if width changes
       const newWidth = entries[0].contentRect.width;
-      if (containerWidth !== newWidth) {
+      if (newWidth !== 0 && containerWidth !== newWidth) {
         // put in an animation frame to stop "benign errors" from
         // ResizObserver https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
         animationFrameID = window.requestAnimationFrame(() => {


### PR DESCRIPTION
This PR avoids a re-layout of the photos when width is 0, ie. when the containing element is hidden.

Layout during width=0 causes the following problems:
1. For an app with tabs, the scroll position of the gallery is not maintained when changing tabs.
2. A complete re-layout is performed, which causes images to re-render causing flicker.

Screencast before:
share.getcloudapp.com/2NuybPlb

Screencast with a fix:
share.getcloudapp.com/6quebvrB

Fixes #185