### PR TITLE
Add initialContainerWidth prop for SSR env

### DIFF
--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -15,8 +15,9 @@ const Gallery = React.memo(function Gallery({
   targetRowHeight,
   columns,
   renderImage,
+  initialContainerWidth,
 }) {
-  const [containerWidth, setContainerWidth] = useState(0);
+  const [containerWidth, setContainerWidth] = useState(initialContainerWidth || 0);
   const galleryEl = useRef(null);
 
   useLayoutEffect(() => {
@@ -122,6 +123,7 @@ Gallery.propTypes = {
   limitNodeSearch: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   margin: PropTypes.number,
   renderImage: PropTypes.func,
+  initialContainerWidth: PropTypes.number,
 };
 
 Gallery.defaultProps = {


### PR DESCRIPTION
I added an `initialContainerWidth` prop to the `Gallery` component, which will allow initial rendering in SSR environments before `useLayoutEffect` can be called.