### PR TITLE
Added key to RenderImageProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,10 @@ export interface RenderImageProps<CustomPhotoProps extends object = {}> {
   direction: 'row' | 'column'
   top?: number
   left?: number
+  /**
+   * key to be used on component
+   */
+  key?: string
 }
 
 export type PhotoClickHandler<CustomPhotoProps extends object = {}> = (


### PR DESCRIPTION
When working on an Esri product that uses this library, I was getting a type error when following the documentation when passing in our own image component. The current RenderImageProps interface does not have a key type, though the documentation shows we have access to a key:
https://codesandbox.io/s/o7o241q09?file=/index.js:355-392

